### PR TITLE
Add oceanic version of the materialshell theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,20 @@
 'use strict';
 
-const backgroundColor = '#151515';
 const foregroundColor = '#A1B0B8';
 const borderColor = '#252525';
-
-const black = '#252525';
-const red = '#FF5252';
-const green = '#C3D82C';
-const yellow = '#FFC135';
-const blue = '#42A5F5';
-const magenta = '#D81B60';
-const cyan = '#00ACC1';
-const white = '#F5F5F5';
-const lightBlack = '#708284';
-const lightRed = '#FF5252';
-const lightGreen = '#C3D82C';
-const lightYellow = '#FFC135';
-const lightBlue = '#42A5F5';
-const lightMagenta = '#D81B60';
-const lightCyan = '#00ACC1';
-const lightWhite = '#F5F5F5';
+const oceanicColors = require('./oceanic-colors');
+const defaultColors = require('./regular-colors');
 
 exports.decorateConfig = config => {
+	let colors;
+	if (config.materialshell && config.materialshell.theme === 'oceanic') {
+		colors = oceanicColors;
+	} else {
+		colors = defaultColors;
+	}
+	const backgroundColor = colors.background;
 	return Object.assign({}, config, {
-		cursorColor: red,
+		cursorColor: colors.red,
 		cursorShape: 'UNDERLINE',
 		foregroundColor,
 		backgroundColor,
@@ -31,25 +22,8 @@ exports.decorateConfig = config => {
 		css: `${config.css || ''}
 		.tab_tab:before {border-left: 1px solid;}
 		.tab_active {background: rgba(255,255,255,0.05);}
-		.tab_active:before {border-color: ${red};}
+		.tab_active:before {border-color: ${colors.red};}
 		`,
-		colors: {
-			black,
-			red,
-			green,
-			yellow,
-			blue,
-			magenta,
-			cyan,
-			white,
-			lightBlack,
-			lightRed,
-			lightGreen,
-			lightYellow,
-			lightBlue,
-			lightMagenta,
-			lightCyan,
-			lightWhite
-		}
+		colors: colors.palette
 	});
 };

--- a/oceanic-colors.js
+++ b/oceanic-colors.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+	palette: {
+		black: '#252525',
+		red: '#FF5252',
+		green: '#C3D82C',
+		yellow: '#FFD740',
+		blue: '#40C4FF',
+		magenta: '#FF4081',
+		cyan: '#18FFFF',
+		white: '#F5F5F5',
+		lightBlack: '#708284',
+		lightRed: '#FF5252',
+		lightGreen: '#C3D82C',
+		lightYellow: '#FFD740',
+		lightBlue: '#40C4FF',
+		lightMagenta: '#FF4081',
+		lightCyan: '#18FFFF',
+		lightWhite: '#F5F5F5'
+	},
+	background: '#263238'
+};

--- a/regular-colors.js
+++ b/regular-colors.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+	palette: {
+		black: '#252525',
+		red: '#FF5252',
+		green: '#C3D82C',
+		yellow: '#FFC135',
+		blue: '#42A5F5',
+		magenta: '#D81B60',
+		cyan: '#00ACC1',
+		white: '#F5F5F5',
+		lightBlack: '#708284',
+		lightRed: '#FF5252',
+		lightGreen: '#C3D82C',
+		lightYellow: '#FFC135',
+		lightBlue: '#42A5F5',
+		lightMagenta: '#D81B60',
+		lightCyan: '#00ACC1',
+		lightWhite: '#F5F5F5'
+	},
+	background: '#151515'
+};


### PR DESCRIPTION
Closes #7

I added the option to configure the color scheme via the `config.materialshell.theme` key in `.hyper.js`.
I also externalize both color schemes into separate files.
(XO lint should be ok).

Happy holidays 🎄😸

<!--
Describe your pull request (What you've done, explain your edits and modifications here.)
-->